### PR TITLE
ZETA-4473: Fix dupe vscode token logic.

### DIFF
--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -1,0 +1,59 @@
+const languages = {
+    createDiagnosticCollection: jest.fn()
+  };
+  
+  const StatusBarAlignment = {};
+  
+  const window = {
+    createStatusBarItem: jest.fn(() => ({
+      show: jest.fn()
+    })),
+    showErrorMessage: jest.fn(),
+    showWarningMessage: jest.fn(),
+    createTextEditorDecorationType: jest.fn()
+  };
+  
+  const workspace = {
+    getConfiguration: jest.fn(),
+    workspaceFolders: [
+      {uri: {fsPath: ''}}
+    ],
+    onDidSaveTextDocument: jest.fn()
+  };
+  
+  const OverviewRulerLane = {
+    Left: null
+  };
+  
+  const Uri = {
+    file: f => f,
+    parse: jest.fn()
+  };
+  const Range = jest.fn();
+  const Diagnostic = jest.fn();
+  const DiagnosticSeverity = { Error: 0, Warning: 1, Information: 2, Hint: 3 };
+  
+  const debug = {
+    onDidTerminateDebugSession: jest.fn(),
+    startDebugging: jest.fn()
+  };
+  
+  const commands = {
+    executeCommand: jest.fn()
+  };
+  
+  const vscode = {
+    languages,
+    StatusBarAlignment,
+    window,
+    workspace,
+    OverviewRulerLane,
+    Uri,
+    Range,
+    Diagnostic,
+    DiagnosticSeverity,
+    debug,
+    commands
+  };
+  
+  module.exports = vscode;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,6 @@ export async function activate(context: vscode.ExtensionContext) {
     COMMAND_AUTH0_AUTH,
     async () => {
       vscode.commands.executeCommand('setContext', 'razroo-vscode-plugin:isAuthenticationInProgress', true);
-      const token = await getOrCreateAndUpdateIdToken(context);
       const loginUrl = getAuth0Url(isProduction);
 
       vscode.window.withProgress(
@@ -87,8 +86,9 @@ export async function activate(context: vscode.ExtensionContext) {
               disposeServer = disposeAndCancelAuth;
               const { accessToken = '', refreshToken = '', userId = '', orgId = '' } = isInProgress ? await createServerPromise : {};
               setWorkspaceState(context, accessToken, refreshToken, userId, orgId, isInProgress);
-              isInProgress && await updatePrivateDirectoriesInVSCodeAuthentication(token!, accessToken, isProduction, userId, orgId);
-              isInProgress && await subscribeToGenerateVsCodeDownloadCodeSub({ vsCodeInstanceId: token, context });
+              const vsCodeInstanceId = await getOrCreateAndUpdateIdToken(context, userId);
+              isInProgress && await updatePrivateDirectoriesInVSCodeAuthentication(vsCodeInstanceId!, accessToken, isProduction, userId, orgId);
+              isInProgress && await subscribeToGenerateVsCodeDownloadCodeSub({ vsCodeInstanceId: vsCodeInstanceId, context });
               isInProgress && vscode.commands.executeCommand('setContext', 'razroo-vscode-plugin:isAuthenticated', true);
               isInProgress && showInformationMessage('User successfully authenticated with Razroo.');
             } catch (error) {

--- a/src/utils/graphql.utils.ts
+++ b/src/utils/graphql.utils.ts
@@ -90,9 +90,10 @@ async function fallback(content) {
 }
 
 async function updatePrivateDirectoriesPostCodeGeneration(context, isProduction: boolean) {
-  const token = await getOrCreateAndUpdateIdToken(context);
-  const accessToken = context.workspaceState.get(MEMENTO_RAZROO_ACCESS_TOKEN);
   const userId = context.workspaceState.get(MEMENTO_RAZROO_USER_ID);
+  const token = await getOrCreateAndUpdateIdToken(context, userId);
+  const accessToken = context.workspaceState.get(MEMENTO_RAZROO_ACCESS_TOKEN);
+  
   const orgId = context.workspaceState.get(MEMENTO_RAZROO_ORG_ID);
   await updatePrivateDirectoriesInVSCodeAuthentication(token, accessToken, isProduction, userId, orgId);
 }

--- a/src/utils/token/token.spec.ts
+++ b/src/utils/token/token.spec.ts
@@ -10,7 +10,8 @@ describe('getOrCreateAndUpdateIdToken', () => {
         get: (test: any) => test
       }
     };
-    const result = getOrCreateAndUpdateIdToken(mockContext as any);
+    const mockUserId = 'abc123';
+    const result = getOrCreateAndUpdateIdToken(mockContext as any, mockUserId);
     const expected = MEMENTO_RAZROO_ID_VS_CODE_TOKEN;
 
     expect(result).toEqual(expected);
@@ -23,8 +24,9 @@ describe('getOrCreateAndUpdateIdToken', () => {
         update: (test: any, newToken) => {}
       }
     };
+    const mockUserId = 'abc123';
     const spy = jest.spyOn(mockContext.workspaceState, 'update');
-    getOrCreateAndUpdateIdToken(mockContext as any);
+    getOrCreateAndUpdateIdToken(mockContext as any, mockUserId);
     const token = MEMENTO_RAZROO_ID_VS_CODE_TOKEN;
 
     expect(spy).toHaveBeenCalledWith(token, expect.anything());

--- a/src/utils/token/token.ts
+++ b/src/utils/token/token.ts
@@ -1,11 +1,10 @@
 import parseGitConfig from 'parse-git-config';
 import { EMPTY, MEMENTO_RAZROO_ID_VS_CODE_TOKEN } from './../../constants';
 import * as vscode from 'vscode';
-import { v4 as uuidv4 } from 'uuid';
 import { extractProjectName } from '@razroo/razroo-codemod';
 import { isEmptyWorkspace } from '../../utils/directory.utils';
 
-export async function getOrCreateAndUpdateIdToken(context: vscode.ExtensionContext): Promise<string> {
+export async function getOrCreateAndUpdateIdToken(context: vscode.ExtensionContext, userId: string): Promise<string> {
     let token: string | undefined = context.workspaceState.get(MEMENTO_RAZROO_ID_VS_CODE_TOKEN);
     if (!token) {
       if(isEmptyWorkspace()) {
@@ -16,7 +15,7 @@ export async function getOrCreateAndUpdateIdToken(context: vscode.ExtensionConte
       const gitOrigin = await parseGitConfig({ cwd: workspacePath, path: '.git/config' }).then(gitConfig => {
         return gitConfig?.['remote "origin"']?.url;
       });
-      token = gitOrigin ? extractProjectName(gitOrigin) : EMPTY;
+      token = gitOrigin ? `${userId}_${extractProjectName(gitOrigin)}` : EMPTY;
       context.workspaceState.update(MEMENTO_RAZROO_ID_VS_CODE_TOKEN, token);
       return token as string;
     }


### PR DESCRIPTION
Now tags userId to vscodeinstanceId so it's a project x userId identifier. Gets the job done for now