### PR TITLE
ZETA-4843: Update vscode logic so ability to choose name of code snippet

### DIFF
--- a/src/snippets/log-position.ts
+++ b/src/snippets/log-position.ts
@@ -41,21 +41,32 @@ export async function logCursorPosition(context: vscode.ExtensionContext, select
       title: 'Choose A Code Snippet'
     });
     if (selectedOption) {
-      codeSnippetGeneratingNotification();
-      const generateVsCodeDownloadCodeParameters = createGenerateVsCodeDownloadCodeParameters(context, (selectedOption as any).orgId as string, (selectedOption as any).pathId, (selectedOption as any).recipeId, (selectedOption as any).id);
       // state here used to freeze logging until snippet has loaded
       context.workspaceState.update(VSCODE_SNIPPET_LOADING, true);
-      generateVsCodeDownloadCode(generateVsCodeDownloadCodeParameters, context, isProduction).then(data => {
+      vscode.window.showInputBox({
+          prompt: `Name for ${selectedOption?.label}?`, // Set the prompt text
+          placeHolder: 'user'  // Set the placeholder text
+      }).then(customName => {
+        // Do something with the custom name
+        codeSnippetGeneratingNotification();
+        const generateVsCodeDownloadCodeParameters = createGenerateVsCodeDownloadCodeParameters(context, (selectedOption as any).orgId as string, (selectedOption as any).pathId, (selectedOption as any).recipeId, (selectedOption as any).id, customName as string);
+        generateVsCodeDownloadCode(generateVsCodeDownloadCodeParameters, context, isProduction).then(data => {
+        }); 
       });
+      
     }
   }
 }
 
 function createGenerateVsCodeDownloadCodeParameters(context, orgId: string,
-    pathId: string, recipeId: string, stepId: string) {
+    pathId: string, recipeId: string, stepId: string, customName: string) {
+  const parameters = {
+    name: customName
+  };
+
   return {
     projectName: '',
-    parameters: undefined,
+    parameters: JSON.stringify(parameters),
     pathOrgId: orgId,
     pathId: pathId,
     recipeId: recipeId,


### PR DESCRIPTION
Now ability for user to choose the name of the function and unfurl that into the code editor

<img width="1284" alt="Screen Shot 2023-03-07 at 12 51 09 AM" src="https://user-images.githubusercontent.com/8540141/223274801-d0938691-3e5e-4a5f-8758-555690633a7f.png">
