### PR TITLE
ZETA-4844: Remove line of comment when generating code snippet.

### DIFF
--- a/src/snippets/write-snippet.ts
+++ b/src/snippets/write-snippet.ts
@@ -11,7 +11,7 @@ export function writeCodeSnippet(context: vscode.ExtensionContext, zipEntry: Adm
   const columnNumber = context.workspaceState.get(VSCODE_ACTIVE_COLUMN_NUMBER) as number;
   const indentedSnippetFileText = indentString(snippetFileText, columnNumber);
   const edit = new vscode.TextEdit(
-    new vscode.Range(lineNumber, 0, lineNumber, 0),
+    new vscode.Range(lineNumber - 1, 0, lineNumber, 0),
     indentedSnippetFileText
   );
   const workspaceEdit = new vscode.WorkspaceEdit();


### PR DESCRIPTION
Remove comment when unfurling code snippet

<img width="668" alt="Screen Shot 2023-03-07 at 1 35 55 AM" src="https://user-images.githubusercontent.com/8540141/223281321-4308bd8e-3997-48ae-bdf9-f8aa70f8abb6.png">
