### PR TITLE
ZETA-4977: Complete directories logic.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,8 +115,6 @@ export async function activate(context: vscode.ExtensionContext) {
   const tryToAuthCommmand = vscode.commands.registerCommand(
     COMMAND_TRY_TO_AUTH,
     async() => {
-      console.log('projectConfigs');
-      console.log(projectConfigs);
       await tryToAuth(context, isProduction, projectsProvider, projectConfigs);
     }
   );

--- a/src/projects/interfaces/project-config.interfaces.ts
+++ b/src/projects/interfaces/project-config.interfaces.ts
@@ -6,4 +6,5 @@ export interface ProjectConfig {
 export interface versionControlParams {
   gitOrigin: string;
   gitBranch: string;
+  path: string;
 }

--- a/src/projects/project-configs.ts
+++ b/src/projects/project-configs.ts
@@ -8,10 +8,12 @@ import { ProjectConfig } from './interfaces/project-config.interfaces';
 export async function getVersionControlParams(workspacePath: string) {
   const gitOrigin = await parseGitConfig({ cwd: workspacePath, path: '.git/config' }).then(gitConfig => gitConfig?.['remote "origin"']?.url);
   const gitBranch = await getBranch(workspacePath);
+  const path = workspacePath;
 
   return {
     gitOrigin,
     gitBranch,
+    path
   };
 }
 


### PR DESCRIPTION
Now if a vscode workspace contains multiple folders
1. Each project identified by git config
2. Package json params aggregated for children of git config
3. Uses filepath of project to get all directories