### PR TITLE
ZETA-4989: Code now generated to its own unique folder x project

### DIFF
--- a/src/utils/graphql.utils.ts
+++ b/src/utils/graphql.utils.ts
@@ -1,3 +1,4 @@
+import { VersionControlParams } from './../projects/interfaces/project-config.interfaces';
 import { ProjectConfig } from '../projects/interfaces/project-config.interfaces';
 import gql from 'graphql-tag';
 import parseGitConfig from 'parse-git-config';
@@ -67,8 +68,9 @@ export const subscribeToGenerateVsCodeDownloadCodeSub = async ({
       });
 
       const realtimeResults = async function realtimeResults(data: any) {
-        //Save the files in a new folder
-        await saveFiles(data, context, isProduction);
+        // Save the files in a new folder
+        const path = selectedProject.versionControlParams.path;
+        await saveFiles(data, context, isProduction, path);
         await updatePrivateDirectoriesPostCodeGeneration(context, isProduction, selectedProjects);
       };
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -35,7 +35,8 @@ export const validateEmail = (email: string) => {
 export const saveFiles = async (
   data: any,
   context: vscode.ExtensionContext,
-  isProduction: boolean
+  isProduction: boolean,
+  path: string
 ) => {
   const url = data.data.generateVsCodeDownloadCodeSub.downloadUrl;
   // parameters will always be a string <-- architected specifically this way
@@ -48,9 +49,7 @@ export const saveFiles = async (
 
   //Get files of S3
   const files = await getFileS3({ url });
-  const rootDirectory = vscode.workspace.workspaceFolders ? process.platform === 'win32' ? normalize(vscode.workspace.workspaceFolders[0].uri.path).slice(1) : normalize(vscode.workspace.workspaceFolders[0].uri.path) : '';
-  const folderSelectedInWorkspace = join(rootDirectory);
-  const folderRoot = `${folderSelectedInWorkspace}`;
+  const folderRoot = path;
 
   //#### TODO REFACTORING MAKE EDIT it's own thing right now inside code generation
   if (type === 'Edit' && updates) {


### PR DESCRIPTION
Can have 10 different folders x project and code will always be generated in the right one, with right values 

<img width="790" alt="Screen Shot 2023-03-22 at 2 30 00 AM" src="https://user-images.githubusercontent.com/8540141/226771814-da4e0ea6-2304-47ea-9983-26cd653f514f.png">
