### PR TITLE
ZETA-4966: Add simple ui to inform user what org they are logged into.

### DIFF
--- a/projects-webview-ui/src/app/app.component.html
+++ b/projects-webview-ui/src/app/app.component.html
@@ -11,7 +11,6 @@
   </vscode-dropdown>
 
   <vscode-button class="App__button" [disabled]="authIsLoading || !(selectedProjects?.length)" (click)="connectProjects(selectedProjects)">{{authIsLoading ? 'Connecting...' : 'Connect'}}</vscode-button>
-  <hr>
   <div *ngIf="orgId && userId" class="App__org">
     <p *ngIf="orgId !== userId"><i>You are logged into {{orgId | titlecase}}</i></p>
     <p *ngIf="orgId === userId"><i>You are logged into your personal workspace</i></p>


### PR DESCRIPTION
If personal workspace will say "You are logged into your personal workspace" 

<img width="830" alt="Screenshot 2023-03-26 at 1 23 05 PM" src="https://user-images.githubusercontent.com/8540141/227769589-6bc42b6f-5807-4969-a73a-6e950bef7eb6.png">
