### PR TITLE
ZETA-5236: Fix version control params logic for update vscode authentication mutation

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -129,7 +129,10 @@ export const updatePrivateDirectoriesInVSCodeAuthentication = async (
     const privateDirectories = path ? await getPrivateDirs(path) : [];
 
     const packageJsonParamsStringified = typeof selectedProject.packageJsonParams === 'object' ? JSON.stringify(selectedProject.packageJsonParams) : selectedProject.packageJsonParams;
-    const versionControlParams = selectedProject.versionControlParams;
+    const versionControlParams = {
+      gitBranch: selectedProject.versionControlParams.gitBranch,
+      gitOrigin: selectedProject.versionControlParams.gitOrigin
+    };
     await updatePrivateDirectoriesRequest({
       vsCodeInstanceId,
       accessToken,


### PR DESCRIPTION
Happened as a result of unified razroo projects logic