### PR TITLE
ZETA-5521: Update vscode auth, so initially shows projects.

### DIFF
--- a/projects-webview-ui/src/app/app.component.ts
+++ b/projects-webview-ui/src/app/app.component.ts
@@ -86,6 +86,8 @@ export class AppComponent implements OnInit {
           return;
         case "sendAuthData":
           this.authIsLoading = false;
+          this.organizations = message.organizations;
+          this.organizationsLoading = false;
           this.isAuthenticated = true;
           this.orgId = message.orgId;
           this.userId = message.userId;

--- a/src/update-vscode/update-vscode.ts
+++ b/src/update-vscode/update-vscode.ts
@@ -6,6 +6,7 @@ import { subscribeToGenerateVsCodeDownloadCodeSub } from "../utils/graphql.utils
 import { getAuth0Url } from '../utils/authentication/authentication';
 import { createVSCodeIdToken } from '../utils/token/token';
 import { ProjectConfig } from '../projects/interfaces/project-config.interfaces';
+import { getUserOrganizations } from '../projects/organizations/organizations.service';
 
 
 export async function updateVsCode(context: vscode.ExtensionContext, isProduction: boolean, selectedProjects: ProjectConfig[], projectsProvider: any) {
@@ -29,9 +30,12 @@ export async function updateVsCode(context: vscode.ExtensionContext, isProductio
             }
           }
           vscode.window.showInformationMessage('User successfully authenticated with Razroo.');
-          if(projectsProvider) { 
+          if(projectsProvider) {
+            const userOrganizations = await getUserOrganizations(userId, isProduction, context);
             await projectsProvider?.view?.webview.postMessage({
               command: "sendAuthData",
+              organizations: userOrganizations,
+              selectedProjects: selectedProjects,
               userId: userId,
               orgId: orgId
             });


### PR DESCRIPTION
Will now show organizations when a user logs out and logs back in again, or is logging for the first time(won't have to click out of plugin and click back in) 

<img width="422" alt="Screenshot 2023-05-20 at 8 45 53 PM" src="https://github.com/razroo/razroo-vscode-plugin/assets/8540141/d043d18d-a7dc-4de1-9470-260d48d62b2c">
