### PR TITLE
ZETA-5501: Will now switch to respective branch when generating a preview.

### DIFF
--- a/src/preview/switch-branch.ts
+++ b/src/preview/switch-branch.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+
+// we will switch users to unique branch when generating preview
+export async function switchToActiveBranch(orgId: string, pathId: string, recipeId: string, stepId: string) {
+  const branchName = `${orgId}/${pathId}/${recipeId}/${stepId}`;
+
+  const execution = new vscode.ShellExecution(`git checkout -B ${branchName}`);
+  const task = new vscode.Task({ type: "shell" }, vscode.TaskScope.Workspace, 'Razroo: Switch To Preview Branch', 'Razroo', execution);
+  return await vscode.tasks.executeTask(task);
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -24,6 +24,7 @@ import {  runRazrooCommand } from './command/command';
 import { writeCodeSnippet } from '../snippets/write-snippet';
 import { createVSCodeIdToken } from './token/token';
 import { refreshAccessToken } from '../graphql/expired';
+import { switchToActiveBranch } from '../preview/switch-branch';
 
 const showInformationMessage = vscode.window.showInformationMessage;
 
@@ -132,6 +133,7 @@ export const saveFiles = async (
           });
 
           if(runPreviewGeneration) {
+            await switchToActiveBranch(template.orgId, template.pathId, template.recipeId, template.id);
             const previewStateObject = {
               templateOrgId: template.orgId,
               pathId: template.pathId,


### PR DESCRIPTION
Will use the usual orgId/pathId/recipeId/stepId so synonymous between web and browser 

<img width="1033" alt="Screenshot 2023-05-22 at 3 52 00 PM" src="https://github.com/razroo/razroo-vscode-plugin/assets/8540141/c1d95ec5-8ec5-490b-8dab-d3f9013e123a">
