### PR TITLE
ZETA-5810: Only subscribe to code if not already subscribed to.

### DIFF
--- a/src/utils/graphql.utils.ts
+++ b/src/utils/graphql.utils.ts
@@ -18,6 +18,8 @@ export function getCommandStatus() {
   commandIsCalled;
 }
 
+const vsCodeInstancesSubscribedTo: string[] = [];
+
 export const subscribeToGenerateVsCodeDownloadCodeSub = async ({
   context, 
   isProduction,
@@ -29,6 +31,12 @@ export const subscribeToGenerateVsCodeDownloadCodeSub = async ({
   for(let selectedProject of selectedProjects) {
     const userOrgId = context.globalState.get(MEMENTO_RAZROO_ORG_ID) as string;
     const vsCodeInstanceId = createVSCodeIdToken(userId, userOrgId, selectedProject.versionControlParams, selectedProject.packageJsonParams, selectedProject.folderName);
+    if(vsCodeInstancesSubscribedTo.includes(vsCodeInstanceId)) {
+      break;
+    } else {
+      vsCodeInstancesSubscribedTo.push(vsCodeInstanceId);
+    }
+
     client(context.globalState.get(MEMENTO_RAZROO_ACCESS_TOKEN), isProduction)
     .hydrated()
     .then(async function (client) {


### PR DESCRIPTION
1. Code gen is subscribed on initial auth
2. Code gen is subscribed to on connect

We had multiple subscriptions being triggered at the same time, causing duplicitous code to be generated. With this new logic, it is now only being triggered, if prior subscription does not already exists 