### PR TITLE
ZETA-5999: Write generated files as binary instead of string

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -106,7 +106,7 @@ export const saveFiles = async (
 
     if (type !== 'edit' && extname(fileName) !== ".sh") {
       try {
-        const fileData = zipEntry.getData().toString("utf8");
+        const fileData = zipEntry.getData();
         const fullPathOfFile = join(folderRoot, fileNameandPath);
         await fse.outputFile(fullPathOfFile, fileData);
         const pathId = template.baseCommunityPath ? template.baseCommunityPath : template.pathId; 


### PR DESCRIPTION
Will allow for images to be generated as is