### PR TITLE
ZETA-8549: Fix access token logic

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -45,7 +45,7 @@ export async function refreshAccessToken(context: vscode.ExtensionContext, isPro
 
 export async function getAccessToken(context: vscode.ExtensionContext, isProduction: boolean) {
   const accessToken = context.globalState.get(MEMENTO_RAZROO_ACCESS_TOKEN) as string;
-  if (isTokenExpired(accessToken)) {
+  if(accessToken && isTokenExpired(accessToken)) {
     const newToken = await refreshAccessToken(context, isProduction);
     return newToken;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -215,7 +215,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
         await tryToAuth(context, isProduction, projectsProvider, projectConfigs, orgId);
       } catch (error) {
-        console.log('COMMAND_TRY_TO_AUTH ERROR');
+        console.log('Connect projects try to auth ERROR');
         console.error(error);
       }
     }


### PR DESCRIPTION
Now only uses the isExpired logic if there is an access token